### PR TITLE
[Feat/#25] 일촌목록 조회 API 연동

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,9 +17,9 @@ function App() {
         <Route path="/" element={<MainPage />} />
         <Route path='/login' element={<LoginPage />} />
         <Route path='/signup' element={<SignupPage />} />
-        <Route path='/list' element={<FriendListPage />} />
-        <Route path='/mypage/' element={<Mypage />} />
-        <Route path='/mypageedit' element={<MypageEdit />} />
+        <Route path='/list/:user_id' element={<FriendListPage />} />
+        <Route path='/mypage' element={<Mypage />} />
+        <Route path='/mypage/edit' element={<MypageEdit />} />
         <Route path='/search' element={<SearchPageMain />} />
         <Route path='/search/result' element={<SearchPage />} />
         <Route path='/chat' element={<ChatPage />} />

--- a/src/components/FriendList.jsx
+++ b/src/components/FriendList.jsx
@@ -1,9 +1,13 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import ProfileModal from './ProfileModal';
+import { useApiUrlStore } from '../store/store';
 
 function FriendList() {
-
+  const { user_id } = useParams()
+  const { apiUrl } = useApiUrlStore()
   const [stausModalOpen, setStatusModalOpen] = useState(false)
+  const [friendlistData, setFriendListData] = useState('')
+  const [friendid, setFriendId] = useState('')
 
   const PostingOpenModal = () => {
     setStatusModalOpen(true)
@@ -12,18 +16,52 @@ function FriendList() {
     setStatusModalOpen(false)
   }
 
+  //친구 목록 조회
+  const getFriendList = async () => {
+    try {
+      const access = localStorage.getItem('session_id')
+      const response = await axios.get(`${apiUrl}/friend/list/${user_id}`,{
+        headers: { Authorization: `Bearer ${access}` },
+      })
+      console.log(response.data)
+      setFriendId(response.data.friend_id)
+    } catch (error) {
+      console.error(error)
+      alert('친구목록을 불러오지 못했습니다')
+    }
+  }
+
+  //친구 정보 조회
+  const getFriend = async (friendid) => {
+    try {
+      const access = localStorage.getItem('session_id')
+      const response = await axios.get(`${apiUrl}/user/${friendid}`,{
+        headers: { Authorization: `Bearer ${access}` },
+      })
+      setFriendListData(response.data)
+    } catch (error) {
+      console.error(error)
+      alert('친구정보를 불러오지 못했습니다')
+    }
+  }
+  
+  useEffect(() => {
+    getFriendList()
+    getFriend()
+  }, [])
+
   return (
     <div className="w-full h-[550px] flex justify-center items-center">
       <div className="w-[650px] h-[500px] bg-custom-white rounded-[10px] overflow-y-auto">
         <div className="flex flex-col justify-center items-center mt-[20px]">
-          {[...Array(10)].map((_, index) => (
+          {friendlistData.map((list) => (
             <div className="w-[600px] min-h-[60px] flex justify-center items-center cursor-pointer" key={index} onClick={PostingOpenModal}>
               <div className="flex items-center justify-between w-[500px] p-[10px] border-b-[1px] border-custom-grey">
-                <div className="text-[16px] h-[24px] font-semibold ">김대희</div>
+                <div className="text-[16px] h-[24px] font-semibold ">{list.name}</div>
                 <div className="flex items-center justify-center w-[350px] p-[5px]">
-                  <div className="text-[16px] mr-[10px]">백엔드 개발자</div>
-                  <div className="text-[16px] mr-[10px]">실리콘밸리</div>
-                  <div className="text-[16px] mr-[10px]">서울시 중구</div>
+                  <div className="text-[16px] mr-[10px]">{list.job}</div>
+                  <div className="text-[16px] mr-[10px]">{list.company}</div>
+                  <div className="text-[16px] mr-[10px]">{list.region}</div>
                 </div>
               </div>
             </div>

--- a/src/components/FriendList.jsx
+++ b/src/components/FriendList.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import ProfileModal from './ProfileModal';
 import { useApiUrlStore } from '../store/store';
-import { useParams } from 'react-router-dom'
+import { NavLink, useParams } from 'react-router-dom'
 import axios from 'axios';
 
 function FriendList() {
@@ -9,9 +9,10 @@ function FriendList() {
   const { apiUrl } = useApiUrlStore()
   const [stausModalOpen, setStatusModalOpen] = useState(false)
   const [friendlistData, setFriendListData] = useState([])
-  const [friendid, setFriendId] = useState('')
+  const [friendId, setFriendId] = useState('')
 
-  const PostingOpenModal = () => {
+  const PostingOpenModal = (id) => {
+    setFriendId(id)
     setStatusModalOpen(true)
   }
   const PostingClosedModal = () => {
@@ -26,14 +27,14 @@ function FriendList() {
       withCredentials: true,
     });
     const friendIds = response.data.map(item => item.friend_id);
-    console.log('Friend IDs:', friendIds);
     friendIds.forEach(friend_id => getFriend(friend_id));
   } catch (error) {
     console.error('Error fetching friend list:', error);
-    alert('친구목록을 불러오지 못했습니다');
+    alert('일촌 목록을 불러오지 못했습니다');
   }
 };
 
+//친구 정보 조회
 const getFriend = async (friend_id) => {
   try {
     const response = await axios.get(`${apiUrl}/users/${friend_id}`, {
@@ -45,10 +46,8 @@ const getFriend = async (friend_id) => {
       }
       return prevFriendListData;
     });
-    console.log('Friend Data:', friendlistData);
   } catch (error) {
     console.error('Error fetching friend data:', error);
-    alert('친구정보를 불러오지 못했습니다');
   }
 };
 
@@ -59,21 +58,22 @@ useEffect(() => {
   return (
     <div className="w-full h-[550px] flex justify-center items-center">
       <div className="w-[650px] h-[500px] bg-custom-white rounded-[10px] overflow-y-auto pt-[20px]">
-      {friendlistData.map((friend, index) => (
-        <div className="flex flex-col items-center justify-center border-b-[1px] border-custom-grey">
-            <div className="w-[500px] min-h-[55px] flex justify-between items-center cursor-pointer " onClick={PostingOpenModal}>
+      {friendlistData.map((friend) => (
+        <div key={friend.id} className="flex flex-col items-center justify-center border-b-[1px] border-custom-grey">
+            <NavLink className="w-[500px] min-h-[55px] flex justify-between items-center cursor-pointer " onClick={()=>PostingOpenModal(friend.id)}>
                 <div className="flex text-[18px] h-[30px] font-semibold w-[80px] items-center justify-center">{friend.name}</div>
                 <div className="flex items-center justify-center w-[350px] p-[5px] ml-[10px]">
                   <div className="flex justify-center items-center text-[16px] mr-[20px] h-[30px] w-[80px]">{friend.job}</div>
                   <div className="flex justify-center items-center text-[16px] mr-[20px] h-[30px] w-[80px]">{friend.company}</div>
                   <div className="flex justify-center items-center text-[16px] h-[30px] w-[80px]">{friend.region}</div>
                 </div>
-            </div>
+            </NavLink>
         </div>
       ))}
       </div>
       {stausModalOpen && (
-        <ProfileModal PostingClosedModal={PostingClosedModal}/>
+        <ProfileModal PostingClosedModal={PostingClosedModal}
+        ProfileId={friendId}/>
       )}
     </div> 
   );

--- a/src/components/FriendList.jsx
+++ b/src/components/FriendList.jsx
@@ -1,12 +1,14 @@
 import React, { useEffect, useState } from 'react';
 import ProfileModal from './ProfileModal';
 import { useApiUrlStore } from '../store/store';
+import { useParams } from 'react-router-dom'
+import axios from 'axios';
 
 function FriendList() {
   const { user_id } = useParams()
   const { apiUrl } = useApiUrlStore()
   const [stausModalOpen, setStatusModalOpen] = useState(false)
-  const [friendlistData, setFriendListData] = useState('')
+  const [friendlistData, setFriendListData] = useState([])
   const [friendid, setFriendId] = useState('')
 
   const PostingOpenModal = () => {
@@ -16,63 +18,64 @@ function FriendList() {
     setStatusModalOpen(false)
   }
 
-  //친구 목록 조회
-  const getFriendList = async () => {
-    try {
-      const access = localStorage.getItem('session_id')
-      const response = await axios.get(`${apiUrl}/friend/list/${user_id}`,{
-        headers: { Authorization: `Bearer ${access}` },
-      })
-      console.log(response.data)
-      setFriendId(response.data.friend_id)
-    } catch (error) {
-      console.error(error)
-      alert('친구목록을 불러오지 못했습니다')
-    }
-  }
-
-  //친구 정보 조회
-  const getFriend = async (friendid) => {
-    try {
-      const access = localStorage.getItem('session_id')
-      const response = await axios.get(`${apiUrl}/user/${friendid}`,{
-        headers: { Authorization: `Bearer ${access}` },
-      })
-      setFriendListData(response.data)
-    } catch (error) {
-      console.error(error)
-      alert('친구정보를 불러오지 못했습니다')
-    }
-  }
   
-  useEffect(() => {
-    getFriendList()
-    getFriend()
-  }, [])
+ // 친구 목록 조회
+ const getFriendList = async () => {
+  try {
+    const response = await axios.get(`${apiUrl}/friends/list/${user_id}`, {
+      withCredentials: true,
+    });
+    const friendIds = response.data.map(item => item.friend_id);
+    console.log('Friend IDs:', friendIds);
+    friendIds.forEach(friend_id => getFriend(friend_id));
+  } catch (error) {
+    console.error('Error fetching friend list:', error);
+    alert('친구목록을 불러오지 못했습니다');
+  }
+};
+
+const getFriend = async (friend_id) => {
+  try {
+    const response = await axios.get(`${apiUrl}/users/${friend_id}`, {
+      withCredentials: true,
+    });
+    setFriendListData(prevFriendListData => {
+      if (!prevFriendListData.some(friend => friend.id === response.data.id)) {
+        return [...prevFriendListData, response.data];
+      }
+      return prevFriendListData;
+    });
+    console.log('Friend Data:', friendlistData);
+  } catch (error) {
+    console.error('Error fetching friend data:', error);
+    alert('친구정보를 불러오지 못했습니다');
+  }
+};
+
+useEffect(() => {
+  getFriendList();
+}, []); 
 
   return (
     <div className="w-full h-[550px] flex justify-center items-center">
-      <div className="w-[650px] h-[500px] bg-custom-white rounded-[10px] overflow-y-auto">
-        <div className="flex flex-col justify-center items-center mt-[20px]">
-          {friendlistData.map((list) => (
-            <div className="w-[600px] min-h-[60px] flex justify-center items-center cursor-pointer" key={index} onClick={PostingOpenModal}>
-              <div className="flex items-center justify-between w-[500px] p-[10px] border-b-[1px] border-custom-grey">
-                <div className="text-[16px] h-[24px] font-semibold ">{list.name}</div>
-                <div className="flex items-center justify-center w-[350px] p-[5px]">
-                  <div className="text-[16px] mr-[10px]">{list.job}</div>
-                  <div className="text-[16px] mr-[10px]">{list.company}</div>
-                  <div className="text-[16px] mr-[10px]">{list.region}</div>
+      <div className="w-[650px] h-[500px] bg-custom-white rounded-[10px] overflow-y-auto pt-[20px]">
+      {friendlistData.map((friend, index) => (
+        <div className="flex flex-col items-center justify-center border-b-[1px] border-custom-grey">
+            <div className="w-[500px] min-h-[55px] flex justify-between items-center cursor-pointer " onClick={PostingOpenModal}>
+                <div className="flex text-[18px] h-[30px] font-semibold w-[80px] items-center justify-center">{friend.name}</div>
+                <div className="flex items-center justify-center w-[350px] p-[5px] ml-[10px]">
+                  <div className="flex justify-center items-center text-[16px] mr-[20px] h-[30px] w-[80px]">{friend.job}</div>
+                  <div className="flex justify-center items-center text-[16px] mr-[20px] h-[30px] w-[80px]">{friend.company}</div>
+                  <div className="flex justify-center items-center text-[16px] h-[30px] w-[80px]">{friend.region}</div>
                 </div>
-              </div>
             </div>
-          ))}
         </div>
+      ))}
       </div>
       {stausModalOpen && (
         <ProfileModal PostingClosedModal={PostingClosedModal}/>
       )}
-    </div>
-    
+    </div> 
   );
 }
 

--- a/src/components/ProfileModal.jsx
+++ b/src/components/ProfileModal.jsx
@@ -1,14 +1,71 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import profileimage from '../assets/images/profileImg2.png';
 import Button from './Button';
 import { MdClose } from "react-icons/md"; 
+import axios from 'axios';
+import { useApiUrlStore } from '../store/store';
 
-function ProfileModal({ PostingClosedModal }) {
+function ProfileModal({ PostingClosedModal, ProfileId }) {
+    const {apiUrl} = useApiUrlStore()
     const [clickedIndex, setClickedIndex] = useState(null);
-
+    const [profileData, setProfileData] = useState('')
+    const [secondfriendlist, SetSecondFriendList] = useState([])
+    
     const handleItemClick = (index) => {
         setClickedIndex(index);
     };
+
+//친구 프로필 정보 조회
+const getFriendProfile = async (ProfileId) => {
+    try {
+      const response = await axios.get(`${apiUrl}/users/${ProfileId}`, {
+        withCredentials: true,
+      });
+      setProfileData(response.data)
+      getFriendList(ProfileId)
+    } catch (error) {
+      console.error('Error fetching friend data:', error);
+      alert('프로필 정보를 불러오지 못했습니다');
+    }
+  };
+  
+  
+  //이촌 목록 조회(친구의 친구)
+  const getFriendList = async (friend_id) => {
+    try {
+      const response = await axios.get(`${apiUrl}/friends/list/${friend_id}`, {
+        withCredentials: true,
+      });
+      const secondFriends = response.data.map(item => item.friend_id);
+      secondFriends.forEach(secondfriend_id => getFriendName(secondfriend_id));
+    } catch (error) {
+      console.error('Error fetching friend list:', error);
+      alert('친구의 일촌목록을 불러오지 못했습니다');
+    }
+  };
+
+  //이촌 정보 조회
+  const getFriendName = async (friend_id) => {
+    try {
+      const response = await axios.get(`${apiUrl}/users/${friend_id}`, {
+        withCredentials: true,
+      });
+      SetSecondFriendList(prevFriendListData => {
+        if (!prevFriendListData.some(friend => friend.id === response.data.id)) {
+          return [...prevFriendListData, response.data];
+        }
+        return prevFriendListData;
+      });
+    } catch (error) {
+      console.error('Error fetching friend list:', error);
+    }
+  };
+
+
+  useEffect(() => {
+    getFriendProfile(ProfileId)
+  }, []); 
+  
 
     return (
         <div className='fixed top-0 flex items-center justify-center w-[calc(100vw-296px)] min-h-screen border-2 backdrop-blur-sm'>
@@ -16,45 +73,45 @@ function ProfileModal({ PostingClosedModal }) {
                 <button className="flex justify-end w-full" onClick={PostingClosedModal}><MdClose className='w-[20px] h-[20px] mr-[10px] mt-[10px]'/></button>
                 <div className='flex flex-col items-center'>
                     <div className='text-[24px] font-black text-custom-indigo underline underline-offset-2 mb-[10px]'>PROFILE</div>
-                    <div className='w-[400px] min-h-[500px] flex flex-col items-center '>
-                        <div className='flex items-center justify-between w-[90%] mt-[10px]'>
-                            <img src={profileimage} className='w-[150px] min-h-[150px]'></img>
-                            <div className='w-[50%] flex justify-between'>
-                                <div className='flex flex-col'>
-                                    <span className='font-semibold mb-[5px]'>이름</span>
-                                    <span className='font-semibold mb-[5px]'>나이</span>
-                                    <span className='font-semibold mb-[5px]'>직업</span>
-                                    <span className='font-semibold mb-[5px]'>위치</span>
-                                    <span className='font-semibold mb-[5px]'>관심 분야</span>
-                                </div>
-                                <div className='flex flex-col'>
-                                    <span className='mb-[5px]'>Jomin-hn</span>
-                                    <span className='mb-[5px]'>27세</span>
-                                    <span className='mb-[5px]'>바리스타</span>
-                                    <span className='mb-[5px]'>서울시 중구</span>
-                                    <span className='mb-[5px]'>창업</span>
-                                </div>
-                            </div>
-                        </div>
-                        <div className='w-[330px] min-h-[215px] m-[35px] flex-col rounded-[10px]'>
-                            <div className='w-full h-[40px] bg-custom-blue flex items-center rounded-t-[10px]'>
-                                <span className='ml-[25px] text-[18px] font-semibold text-custom-white'>일촌 목록</span>
-                            </div>
-                            <div className='flex-col w-full h-[220px] overflow-y-auto bg-custom-white rounded-b-[10px]'>
-                                {['김민지', '이철수', '박영희', '홍길동', '이순신'].map((name, index) => (
-                                    <div
-                                        key={index}
-                                        className={`flex w-full min-h-[40px] justify-between border-b-[1px] border-custom-grey cursor-pointer ${clickedIndex === index ? 'bg-custom-orange bg-opacity-50 border-custom-orange border-2 font-bold' : ''}`}
-                                        onClick={() => handleItemClick(index)}
-                                    >
-                                        <div className='flex items-center ml-[30px]'>{name}</div>
-                                        <div className='flex items-center text-[14px] text-custom-blue mr-[30px]'>#테니스</div>
+                        <div className='w-[400px] min-h-[500px] flex flex-col items-center'>
+                            <div className='flex items-center justify-between mt-[10px]'>
+                                <img src={profileimage} className='w-[150px] min-h-[150px]'></img>
+                                <div className='flex justify-between ml-[10px]'>
+                                    <div className='flex flex-col'>
+                                        <span className='font-semibold w-[80px] h-[30px] flex items-center justify-start'>이름</span>
+                                        <span className='font-semibold w-[80px] h-[30px] flex items-center justify-start'>나이</span>
+                                        <span className='font-semibold w-[80px] h-[30px] flex items-center justify-start'>직업</span>
+                                        <span className='font-semibold w-[80px] h-[30px] flex items-center justify-start'>위치</span>
+                                        <span className='font-semibold w-[80px] h-[30px] flex items-center justify-start'>관심 분야</span>
                                     </div>
-                                ))}
+                                    <div className='flex flex-col ml-[10px]'>
+                                        <span className='h-[30px] flex items-center justify-start'>{profileData.name}</span>
+                                        <span className='h-[30px] flex items-center justify-start'>{profileData.age}</span>
+                                        <span className='h-[30px] flex items-center justify-start'>{profileData.job}</span>
+                                        <span className='h-[30px] flex items-center justify-start'>{profileData.region}</span>
+                                        <span className='h-[30px] flex items-center justify-start'>{profileData.category}</span>
+                                    </div>
+                                </div>
                             </div>
+                            <div className='w-[330px] min-h-[215px] m-[35px] flex-col rounded-[10px]'>
+                                <div className='w-full h-[40px] bg-custom-blue flex items-center rounded-t-[10px]'>
+                                    <span className='ml-[25px] text-[18px] font-semibold text-custom-white'>일촌 목록</span>
+                                </div>
+                                <div className='flex-col w-full h-[220px] overflow-y-auto bg-custom-white rounded-b-[10px]'>
+                                    {secondfriendlist.map((secondfriend,index) => (
+                                        <div
+                                            key={secondfriend.id}
+                                            className={`flex w-full min-h-[40px] justify-between border-b-[1px] border-custom-grey cursor-pointer ${clickedIndex === index ? 'bg-custom-orange bg-opacity-50 border-custom-orange border-2 font-bold' : ''}`}
+                                            onClick={() => handleItemClick(index)}
+                                        >
+                                            <div className='flex items-center ml-[30px]'>{secondfriend.name}</div>
+                                            <div className='flex items-center text-[14px] text-custom-blue mr-[30px]'>#{secondfriend.category}</div>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                            <Button label={"소개 받기"} />
                         </div>
-                        <Button label={"소개 받기"} />
-                    </div>
                 </div>
             </div>
         </div>

--- a/src/pages/FriendListPage.jsx
+++ b/src/pages/FriendListPage.jsx
@@ -5,6 +5,7 @@ import FriendList from '../components/FriendList';
 
 
 
+
 function FriendListPage() {
   const [sortOption, setSortOption] = useState('graph')
   
@@ -17,6 +18,8 @@ function FriendListPage() {
     setSortOption(e.target.value)
     console.log(sortOption)
   }
+
+   
   
   return (
    <div className='flex'>

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -4,6 +4,11 @@ import Button from '../components/Button';
 import axios from "axios";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useApiUrlStore } from "../store/store";
+
+
+
+
 function LoginPage() {
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
@@ -14,9 +19,9 @@ function LoginPage() {
         try {
             const response = await axios.post('http://localhost:8000/api/v1/auth/login', {email, password}, {withCredentials: true});
             window.alert('로그인 성공');
-            setTimeout(() => {
-                navigate('/mypage');
-            }, 2000);
+            const userid = response.data.user_id;
+            console.log(response.data)
+             navigate(`/list/${userid}`);
         } catch (err) {
             window.alert('로그인 실패');
             console.log(err);

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,0 +1,15 @@
+import { create } from 'zustand';
+
+/**
+ * Zustand 상태 관리를 위한 store를 생성합니다.
+ * 이 store는 `apiUrl` 상태와 `setApiUrl` 액션을 관리합니다.
+ * 
+ * `apiUrl`은 API 요청을 보낼 기본 URL을 저장합니다.
+ * `setApiUrl`은 `apiUrl` 상태를 업데이트하는 함수입니다.
+ */
+export const useApiUrlStore = create((set) => ({
+
+  apiUrl: 'https://localhost:8000/',
+
+  setApiUrl: (url) => set((state) => ({ ...state, apiUrl: url })),
+}));

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -9,7 +9,7 @@ import { create } from 'zustand';
  */
 export const useApiUrlStore = create((set) => ({
 
-  apiUrl: 'https://localhost:8000/',
+  apiUrl: 'https://localhost:8000/api/v1',
 
   setApiUrl: (url) => set((state) => ({ ...state, apiUrl: url })),
 }));

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -9,7 +9,7 @@ import { create } from 'zustand';
  */
 export const useApiUrlStore = create((set) => ({
 
-  apiUrl: 'https://localhost:8000/api/v1',
+  apiUrl: 'http://localhost:8000/api/v1',
 
   setApiUrl: (url) => set((state) => ({ ...state, apiUrl: url })),
 }));


### PR DESCRIPTION
## 💻구현 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)
- 일촌 목록 조회 
- 일촌 프로필 조회
- 이촌 목록 조회

![image](https://github.com/user-attachments/assets/94a4f6ba-77f4-4488-ba05-ab1fdfec10ff)
![image](https://github.com/user-attachments/assets/c9a314ee-1360-43c3-8b96-e4eca073fb4d)


<br><br>
## 💬리뷰 요구사항(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- 현재 로그인에서 일촌리스트 페이지로 넘어오면 사이드바에 Friend List부분이 선택이 되지만, 다른 페이지를 갔다가 사이드바를 선택해서 오면 user_id를 받아오지못해 선택이 안되는데 추후 사이드바 정보 변경할때 같이 수정 부탁드립니다
- zustand 이용하여 api주소 변경하였으니 참고하셔서 적용하여 api 수정해주시면 됩니다!

<br><br>
## #️⃣연관된 이슈
> 아래에 {이슈번호}를 작성해주세요
<br>
close #25 

<br><br>
## ✅Check List
- [x] PR 제목 규칙
- [x] 추가/수정사항
- [x] 이슈번호

